### PR TITLE
Expand JSON compat to support v1.x

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,7 +7,7 @@ JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 
 [compat]
 julia = "1.0"
-JSON = "~0.21.0"
+JSON = "0.21, 1"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"


### PR DESCRIPTION
## Summary

- Updates JSON compat from `~0.21.0` to `0.21, 1` to allow JSON v1.x
- No source changes needed — `NoveltyColors.jl` only uses `JSON.parsefile`, which is still available in JSON v1.x

## Test plan

- [ ] Verify `using NoveltyColors` loads successfully with JSON v1.x
- [ ] Confirm all color palettes load correctly (`length(ColorDict) == 5`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)